### PR TITLE
Deleted "container" for this branch

### DIFF
--- a/src/partials/how-its-made.html
+++ b/src/partials/how-its-made.html
@@ -1,5 +1,5 @@
 <section id="made" class="how-its-made">
-  <div class="container container--how-its-made">
+  <div class="container--how-its-made">
     <div class="how-its-made__title">
       <h3 class="how-its-made__title-first">tradition and love</h3>
       <h2 class="how-its-made__title-second">how it’s made?</h2>


### PR DESCRIPTION
Deleted "container" class for 'How it's made' section to fix an overwriting issue with "container--how-its-made" class